### PR TITLE
Setup config and logger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
 .idea/
-go.mod
-go.sum
 .gitignore
 .env

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"log/slog"
+	"os"
+	"pulse-auth/internal/config"
+)
+
+const (
+	envDev  = "dev"
+	envProd = "prod"
+)
+
+func main() {
+	cfg := config.New()
+
+	log := setupLogger(cfg.Env)
+	log = log.With(slog.String("env", cfg.Env))
+
+	log.Info("Start server", slog.String("address", cfg.Address))
+	log.Debug("Debug mode enable")
+}
+
+func setupLogger(env string) *slog.Logger {
+	var logger *slog.Logger
+
+	switch env {
+	case envDev:
+		logger = slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	case envProd:
+		logger = slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	}
+	return logger
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,12 @@
+module pulse-auth
+
+go 1.22.0
+
+require (
+	github.com/BurntSushi/toml v1.3.2 // indirect
+	github.com/go-chi/chi/v5 v5.0.12 // indirect
+	github.com/ilyakaznacheev/cleanenv v1.5.0 // indirect
+	github.com/joho/godotenv v1.5.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+	olympos.io/encoding/edn v0.0.0-20201019073823-d3554ca0b0a3 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,14 @@
+github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
+github.com/BurntSushi/toml v1.3.2 h1:o7IhLm0Msx3BaB+n3Ag7L8EVlByGnpq14C4YWiu/gL8=
+github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
+github.com/go-chi/chi/v5 v5.0.12 h1:9euLV5sTrTNTRUU9POmDUvfxyj6LAABLUcEWO+JJb4s=
+github.com/go-chi/chi/v5 v5.0.12/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
+github.com/ilyakaznacheev/cleanenv v1.5.0 h1:0VNZXggJE2OYdXE87bfSSwGxeiGt9moSR2lOrsHHvr4=
+github.com/ilyakaznacheev/cleanenv v1.5.0/go.mod h1:a5aDzaJrLCQZsazHol1w8InnDcOX0OColm64SlIi6gk=
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+olympos.io/encoding/edn v0.0.0-20201019073823-d3554ca0b0a3 h1:slmdOY3vp8a7KQbHkL+FLbvbkgMqmXojpFUO/jENuqQ=
+olympos.io/encoding/edn v0.0.0-20201019073823-d3554ca0b0a3/go.mod h1:oVgVk4OWVDi43qWBEyGhXgYxt7+ED4iYNpTngSLX2Iw=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,56 @@
+package config
+
+import (
+	"github.com/ilyakaznacheev/cleanenv"
+	"github.com/joho/godotenv"
+	"log"
+	"os"
+	"time"
+)
+
+type Config struct {
+	Env        string `yaml:"env" env-default:"dev"`
+	HttpServer `yaml:"http_server"`
+	DB         Storage
+}
+
+type HttpServer struct {
+	Address     string        `yaml:"address"`
+	Timeout     time.Duration `yaml:"timeout" env-default:"5s"`
+	IdleTimeout time.Duration `yaml:"idle_timeout" env-default:"60s"`
+}
+
+type Storage struct {
+	Name     string `env:"DB_NAME"`
+	Port     int    `env:"DB_PORT"`
+	Username string `env:"DB_USER"`
+	Password string `env:"DB_PASSWORD"`
+}
+
+func New() *Config {
+	if err := godotenv.Load(); err != nil {
+		log.Fatal("No .env file found")
+	}
+
+	configPath := getEnv("CONFIG_PATH", "")
+	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+		log.Fatalf("configs file doesn't exist: %s", configPath)
+	}
+
+	var cfg Config
+
+	if err := cleanenv.ReadConfig(configPath, &cfg); err != nil {
+		log.Fatalf("can't read configs from %s: %v", configPath, err)
+	}
+	return &cfg
+
+}
+
+// Simple helper function to read an environment or return a default value
+func getEnv(key string, defaultVal string) string {
+	if value, exists := os.LookupEnv(key); exists {
+		return value
+	}
+
+	return defaultVal
+}

--- a/internal/config/config.yml
+++ b/internal/config/config.yml
@@ -1,0 +1,5 @@
+env: "dev" # dev, prod
+http_server:
+  address: "localhost:8087"
+  timeouts: 4s
+  idle_timeout: 30s


### PR DESCRIPTION
This pull request closes #1 

Setup service config, which provides these hidden variables
```
CONFIG_PATH =

DB_USER = 
DB_PASSWORD = 
DB_NAME = 
DB_PORT = 
```

In open config.yml have environment and http server settings
```
env: "dev" # dev, prod
http_server:
  address: "localhost:8087"
  timeouts: 4s
  idle_timeout: 30s
```
***
Basic slog logger divide into two different logger depends on environment 
```go
switch env {
case envDev:
	logger = slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
case envProd:
	logger = slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))

}
```

